### PR TITLE
build: GitHub Actions and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+    reviewers:
+      - Health-Education-England/trainee-backend
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    reviewers:
+      - Health-Education-England/trainee-backend
+      - Health-Education-England/trainee-devops

--- a/.github/workflows/pr-analysis.yml
+++ b/.github/workflows/pr-analysis.yml
@@ -1,0 +1,11 @@
+name: PR Analysis
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  analysis:
+    name: Analyse PR
+    uses: health-education-england/.github/.github/workflows/pr-analysis-common.yml@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish to Maven Central
+
+on:
+  workflow_dispatch:
+
+jobs:
+  increment-version:
+    name: Auto Increment Version
+    uses: health-education-england/.github/.github/workflows/auto-version.yml@main
+
+  publish:
+    name: Publish
+    needs: increment-version
+    runs-on: ubuntu-latest
+    if: needs.increment-version.outputs.new-version
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          cache: gradle
+          distribution: temurin
+          java-version: 21
+
+      - name: Publish
+        run: ./gradlew publishToMavenLocal
+
+      # Temporary step to allow verification of the built dependency.
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: uk.nhs.tis.trainee_version-catalog_${{ needs.increment-version.outputs.new-version }}
+          path: ~/.m2/uk/tis/nhs/tis/trainee/version-catalog/${{ needs.increment-version.outputs.new-version }}/


### PR DESCRIPTION
Create a dependendabot config and workflows for PR Analysis and Maven Publishing.

Initial the maven publishing should only publish to the local maven repo and upload the artifact. Once secrets/credentials are in place for Maven Central publishing the local-only restriction can be lifted.

NO-TICKET