### PR TITLE
build: use PAT for auto commit permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ jobs:
   increment-version:
     name: Auto Increment Version
     uses: health-education-england/.github/.github/workflows/auto-version.yml@main
+    secrets:
+      commit-pat: ${{ secrets.PAT_AUTOMATED_COMMITS }}
 
   publish:
     name: Publish


### PR DESCRIPTION
The auto version workflow now requires a PAT to enable branch protection rules to be bypassed when commiting the changes.
Pass a suitable PAT to the reusable workflow.

NO-TICKET