### PR TITLE
chore(deps): upgrade Sentry and XRay minor version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,10 +2,10 @@
 mapstruct = "1.5.5.Final"
 mongock = "5.4.4"
 openhtmltopdf = "1.0.10"
-sentry = "7.6.0"
+sentry = "7.20.1"
 
 [libraries]
-aws-xray = { module = "com.amazonaws:aws-xray-recorder-sdk-spring", version = "2.15.3"}
+aws-xray = { module = "com.amazonaws:aws-xray-recorder-sdk-spring", version = "2.18.2"}
 jsoup = { module = "org.jsoup:jsoup", version = "1.17.2"}
 mapstruct-core = { module = "org.mapstruct:mapstruct", version.ref = "mapstruct" }
 mapstruct-processor = { module = "org.mapstruct:mapstruct-processor", version.ref = "mapstruct"}


### PR DESCRIPTION
Update Sentry and AWS X-Ray minor version to ensure that no trainee services are downgraded when adopting the version catalog. Other dependencies also have minor version bumps available, but the catalog is currently matching or higher than the trainee services.

Once all services are migrated a more controlled and consistent upgrade of all remaining dependencies can be performed.

NO-TICKET