### PR TITLE
chore(deps): upgrade to supported AWS/Azure versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,8 +16,8 @@ openhtmltopdf-slf4j = { module = "com.openhtmltopdf:openhtmltopdf-slf4j", versio
 sentry-core = { module = "io.sentry:sentry-spring-boot-starter-jakarta", version.ref = "sentry" }
 sentry-logback = { module = "io.sentry:sentry-logback", version.ref = "sentry"}
 spring-cloud-dependencies-core = { module = "org.springframework.cloud:spring-cloud-dependencies", version = "2023.0.5"}
-spring-cloud-dependencies-aws = { module = "io.awspring.cloud:spring-cloud-aws-dependencies", version = "3.1.1"}
-spring-cloud-dependencies-azure = { module = "com.azure.spring:spring-cloud-azure-dependencies", version = "5.9.1"}
+spring-cloud-dependencies-aws = { module = "io.awspring.cloud:spring-cloud-aws-dependencies", version = "3.2.1"}
+spring-cloud-dependencies-azure = { module = "com.azure.spring:spring-cloud-azure-dependencies", version = "5.19.0"}
 
 [bundles]
 mongock = ["mongock-core", "mongock-driver"]


### PR DESCRIPTION
The current version of Spring Cloud AWS and Spring Cloud Azure did not officially support Spring Boot version `3.3.x`.

Upgrade to the latest compatible version of both AWS and Azure BOMs, both are backwards compatible with Spring Boot `3.2.x` and the latest Azure also supports Spring Boot `3.4.x`.

NO-TICKET