### PR TITLE
test: create initial integration test project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,10 +6,6 @@ plugins {
   id("com.vanniktech.maven.publish") version "0.30.0"
 }
 
-repositories {
-  mavenCentral()
-}
-
 group = "uk.nhs.tis.trainee"
 version = "0.0.6"
 

--- a/compatibility-testing/build.gradle.kts
+++ b/compatibility-testing/build.gradle.kts
@@ -1,0 +1,79 @@
+plugins {
+  java
+  alias(libs.plugins.spring.boot)
+  alias(libs.plugins.spring.dependency.management)
+}
+
+group = "uk.nhs.tis.trainee.versioncatalog"
+version = "0.0.1"
+
+configurations {
+  compileOnly {
+    extendsFrom(configurations.annotationProcessor.get())
+  }
+}
+
+dependencyManagement {
+  imports {
+    mavenBom(libs.spring.cloud.dependencies.core.get().toString())
+    mavenBom(libs.spring.cloud.dependencies.aws.get().toString())
+  }
+}
+
+dependencies {
+  // Spring Boot
+  implementation("org.springframework.boot:spring-boot-starter-actuator")
+  implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
+  implementation("org.springframework.boot:spring-boot-starter-data-redis")
+  implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+  implementation("org.springframework.boot:spring-boot-starter-validation")
+  implementation("org.springframework.boot:spring-boot-starter-web")
+
+  // Lombok
+  compileOnly("org.projectlombok:lombok")
+  annotationProcessor("org.projectlombok:lombok")
+
+  // Mapstruct
+  implementation(libs.mapstruct.core)
+  annotationProcessor(libs.mapstruct.processor)
+
+  // Amazon AWS
+  implementation("io.awspring.cloud:spring-cloud-aws-starter-sqs")
+  implementation("io.awspring.cloud:spring-cloud-aws-starter-sns")
+  implementation(libs.aws.xray)
+
+  // PDF
+  implementation(libs.bundles.pdf.publishing)
+}
+
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(21))
+    vendor.set(JvmVendorSpec.ADOPTIUM)
+  }
+}
+
+testing {
+  suites {
+
+    register<JvmTestSuite>("integrationTest") {
+      useJUnitJupiter()
+      dependencies {
+        implementation(project())
+        implementation("org.springframework.boot:spring-boot-starter-test")
+        implementation("org.springframework.boot:spring-boot-testcontainers")
+        implementation("org.testcontainers:localstack")
+        implementation("org.testcontainers:mongodb")
+      }
+    }
+
+    // Include implementation dependencies.
+    val integrationTestImplementation by configurations.getting {
+      extendsFrom(configurations.implementation.get())
+    }
+  }
+}
+
+tasks.named("check") {
+  dependsOn(testing.suites.named("integrationTest"))
+}

--- a/compatibility-testing/src/integrationTest/java/uk/nhs/tis/trainee/versioncatalog/CompatibilityTestingApplicationIntegrationTest.java
+++ b/compatibility-testing/src/integrationTest/java/uk/nhs/tis/trainee/versioncatalog/CompatibilityTestingApplicationIntegrationTest.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.versioncatalog;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@SpringBootTest
+@Import(ContainerConfiguration.class)
+class CompatibilityTestingApplicationIntegrationTest {
+
+  @Test
+  void contextLoads() {
+
+  }
+}

--- a/compatibility-testing/src/integrationTest/java/uk/nhs/tis/trainee/versioncatalog/ContainerConfiguration.java
+++ b/compatibility-testing/src/integrationTest/java/uk/nhs/tis/trainee/versioncatalog/ContainerConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.versioncatalog;
+
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
+import static org.testcontainers.utility.DockerImageName.parse;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+
+/**
+ * Configuration for the required test containers.
+ */
+@TestConfiguration(proxyBeanMethods = false)
+public class ContainerConfiguration {
+
+  /**
+   * Create a LocalStack container.
+   *
+   * @param registry The registry to add localstack properties to.
+   * @return The created container.
+   */
+  @Bean
+  LocalStackContainer localStackContainer(DynamicPropertyRegistry registry) {
+    LocalStackContainer localStackContainer = new LocalStackContainer(
+      parse("localstack/localstack:3"))
+      .withServices(SQS);
+
+    registry.add("spring.cloud.aws.region.static", localStackContainer::getRegion);
+    registry.add("spring.cloud.aws.credentials.access-key", localStackContainer::getAccessKey);
+    registry.add("spring.cloud.aws.credentials.secret-key", localStackContainer::getSecretKey);
+    registry.add("spring.cloud.aws.sqs.endpoint",
+      () -> localStackContainer.getEndpointOverride(SQS).toString());
+    registry.add("spring.cloud.aws.sqs.enabled", () -> true);
+
+    return localStackContainer;
+  }
+
+  /**
+   * Create a MongoDB container.
+   *
+   * @return The created container.
+   */
+  @Bean
+  @ServiceConnection
+  MongoDBContainer mongoContainer() {
+    return new MongoDBContainer(parse("mongo:5"));
+  }
+}

--- a/compatibility-testing/src/integrationTest/java/uk/nhs/tis/trainee/versioncatalog/TestApplication.java
+++ b/compatibility-testing/src/integrationTest/java/uk/nhs/tis/trainee/versioncatalog/TestApplication.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.versioncatalog;
+
+import org.springframework.boot.SpringApplication;
+
+/**
+ * A test application to allow running locally using test containers.
+ */
+public class TestApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.from(CompatibilityTestingApplication::main)
+      .with(ContainerConfiguration.class)
+      .run(args);
+  }
+}

--- a/compatibility-testing/src/main/java/uk/nhs/tis/trainee/versioncatalog/CompatibilityTestingApplication.java
+++ b/compatibility-testing/src/main/java/uk/nhs/tis/trainee/versioncatalog/CompatibilityTestingApplication.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.versioncatalog;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * An application for testing version catalog dependency compatibility.
+ */
+@SpringBootApplication
+public class CompatibilityTestingApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(CompatibilityTestingApplication.class);
+  }
+}

--- a/compatibility-testing/src/main/resources/application.yml
+++ b/compatibility-testing/src/main/resources/application.yml
@@ -1,0 +1,2 @@
+server:
+  port: 0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,8 @@
 rootProject.name = "tis-trainee-version-catalog"
+include("compatibility-testing")
+
+dependencyResolutionManagement {
+  repositories {
+    mavenCentral()
+  }
+}


### PR DESCRIPTION
Create an initial sub-project for integration testing compatibility of the version catalog.
The initial test will simply verify that the application can be started with the given combination of dependencies, using TestContainers where needed to run local services.

Future work will look to add tests for more real-life scenarios, like message publishing/listening and producing PDFs to ensure that updated dependencies don't risk breaking ALL of our services using the catalog.

NO-TICKET