### PR TITLE
build(deps): bulk update deps for Spring Boot 3.5

### DIFF
--- a/compatibility-testing/src/integrationTest/java/uk/nhs/tis/trainee/versioncatalog/ContainerConfiguration.java
+++ b/compatibility-testing/src/integrationTest/java/uk/nhs/tis/trainee/versioncatalog/ContainerConfiguration.java
@@ -27,7 +27,7 @@ import static org.testcontainers.utility.DockerImageName.parse;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertyRegistrar;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 
@@ -40,23 +40,31 @@ public class ContainerConfiguration {
   /**
    * Create a LocalStack container.
    *
-   * @param registry The registry to add localstack properties to.
    * @return The created container.
    */
   @Bean
-  LocalStackContainer localStackContainer(DynamicPropertyRegistry registry) {
-    LocalStackContainer localStackContainer = new LocalStackContainer(
+  LocalStackContainer localStackContainer() {
+    return new LocalStackContainer(
       parse("localstack/localstack:3"))
       .withServices(SQS);
+  }
 
-    registry.add("spring.cloud.aws.region.static", localStackContainer::getRegion);
-    registry.add("spring.cloud.aws.credentials.access-key", localStackContainer::getAccessKey);
-    registry.add("spring.cloud.aws.credentials.secret-key", localStackContainer::getSecretKey);
-    registry.add("spring.cloud.aws.sqs.endpoint",
-      () -> localStackContainer.getEndpointOverride(SQS).toString());
-    registry.add("spring.cloud.aws.sqs.enabled", () -> true);
-
-    return localStackContainer;
+  /**
+   * Create a property registrar for configuring localstack properties.
+   *
+   * @param container The container associated with the properties.
+   * @return The created registrar.
+   */
+  @Bean
+  DynamicPropertyRegistrar localstackProperties(LocalStackContainer container) {
+    return registry -> {
+      registry.add("spring.cloud.aws.region.static", container::getRegion);
+      registry.add("spring.cloud.aws.credentials.access-key", container::getAccessKey);
+      registry.add("spring.cloud.aws.credentials.secret-key", container::getSecretKey);
+      registry.add("spring.cloud.aws.sqs.endpoint",
+        () -> container.getEndpointOverride(SQS).toString());
+      registry.add("spring.cloud.aws.sqs.enabled", () -> true);
+    };
   }
 
   /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,16 @@
 [versions]
 mapstruct = "1.6.3"
 mongock = "5.5.1"
-openhtmltopdf = "1.1.29"
-sentry = "8.21.1"
+openhtmltopdf = "1.1.37"
+sentry = "8.32.0"
 shedlock = "6.9.2"
-xray = "2.18.3"
+xray = "2.20.0"
 
 [libraries]
 aws-xray-instrumentor = { module = "com.amazonaws:aws-xray-recorder-sdk-aws-sdk-v2-instrumentor", version.ref = "xray"}
 aws-xray-sdk = { module = "com.amazonaws:aws-xray-recorder-sdk-aws-sdk-v2", version.ref = "xray"}
 aws-xray-spring = { module = "com.amazonaws:aws-xray-recorder-sdk-spring", version.ref = "xray"}
-jsoup = { module = "org.jsoup:jsoup", version = "1.21.2"}
+jsoup = { module = "org.jsoup:jsoup", version = "1.22.1"}
 mapstruct-core = { module = "org.mapstruct:mapstruct", version.ref = "mapstruct" }
 mapstruct-processor = { module = "org.mapstruct:mapstruct-processor", version.ref = "mapstruct"}
 mongock-core = { module = "io.mongock:mongock-springboot", version.ref = "mongock" }
@@ -22,9 +22,9 @@ sentry-core = { module = "io.sentry:sentry-spring-boot-starter-jakarta", version
 sentry-logback = { module = "io.sentry:sentry-logback", version.ref = "sentry"}
 shedlock-spring = { module = "net.javacrumbs.shedlock:shedlock-spring", version.ref = "shedlock"}
 shedlock-provider-mongo = { module = "net.javacrumbs.shedlock:shedlock-provider-mongo", version.ref = "shedlock"}
-spring-cloud-dependencies-core = { module = "org.springframework.cloud:spring-cloud-dependencies", version = "2023.0.5"}
-spring-cloud-dependencies-aws = { module = "io.awspring.cloud:spring-cloud-aws-dependencies", version = "3.2.1"}
-spring-cloud-dependencies-azure = { module = "com.azure.spring:spring-cloud-azure-dependencies", version = "5.19.0"}
+spring-cloud-dependencies-core = { module = "org.springframework.cloud:spring-cloud-dependencies", version = "2025.0.1"}
+spring-cloud-dependencies-aws = { module = "io.awspring.cloud:spring-cloud-aws-dependencies", version = "3.4.2"}
+spring-cloud-dependencies-azure = { module = "com.azure.spring:spring-cloud-azure-dependencies", version = "6.1.0"}
 
 [bundles]
 aws-xray = ["aws-xray-instrumentor", "aws-xray-sdk", "aws-xray-spring"]
@@ -34,6 +34,6 @@ sentry = ["sentry-core", "sentry-logback"]
 shedlock-mongo = ["shedlock-spring", "shedlock-provider-mongo"]
 
 [plugins]
-sonarqube = { id = "org.sonarqube", version = "6.2.0.5505"}
-spring-boot = { id = "org.springframework.boot", version = "3.3.11"}
+sonarqube = { id = "org.sonarqube", version = "7.2.2.6593"}
+spring-boot = { id = "org.springframework.boot", version = "3.5.10"}
 spring-dependency-management = { id = "io.spring.dependency-management", version = "1.1.7"}


### PR DESCRIPTION
Upgrade Spring Boot to the latest `3.5.x` version, Spring Cloud dependencies should be updated to the latest `3.5.x` compatible versions.

Other dependencies should be upgraded to the latest available versions.

For migration help see:
 - https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.4-Release-Notes
 - https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.5-Release-Notes

NO-TICKET